### PR TITLE
yajl 1.0.0 doesn't work with ruby 1.9.3

### DIFF
--- a/fluent-logger.gemspec
+++ b/fluent-logger.gemspec
@@ -35,7 +35,7 @@ EOF
   gem.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   gem.require_paths = ['lib']
 
-  gem.add_dependency 'yajl-ruby', '~> 1.0.0'
+  gem.add_dependency 'yajl-ruby', '~> 1.1'
   gem.add_dependency 'msgpack', '~> 0.4.4'
   gem.add_development_dependency 'rake', '>= 0.9.2'
   gem.add_development_dependency 'rspec', '>= 2.7.0'


### PR DESCRIPTION
I used fluent-logger-ruby with ruby 1.9.3p125 and got this error message.
https://gist.github.com/2476820
yajl 1.0.0 doesn't work with ruby 1.9.3.
So, we should use yajl 1.1.0.
https://github.com/brianmario/yajl-ruby/issues/87
