### PR TITLE
log reconnect error

### DIFF
--- a/spec/fluent_logger_spec.rb
+++ b/spec/fluent_logger_spec.rb
@@ -213,6 +213,19 @@ EOF
         logger_io.rewind
         logger_io.read.should =~ /Can't send logs to/
       end
+
+      it ('log connect error once') do
+        logger.stub(:suppress_sec).and_return(-1)
+        logger.log_reconnect_error_threshold = 1
+        logger.should_receive(:log_reconnect_error).once.and_call_original
+
+        logger.post('tag', {'a' => 'b'})
+        wait_transfer  # even if wait
+        logger.post('tag', {'a' => 'b'})
+        wait_transfer  # even if wait
+        logger_io.rewind
+        logger_io.read.should =~ /Can't connect to/
+      end
     end
   end
 


### PR DESCRIPTION
My application, use fluent-logger-ruby, encountered network issue.
I investigated extent of the impact. 
However, fluent-logger-ruby write log when buffer reaches limit.
Probablly my network issues was solved before that.
So I like to log when fluent-logger-ruby fail to connect several times for investigating.
