### PR TITLE
Accept msgpack 0.4.7 or later

### DIFF
--- a/fluent-logger.gemspec
+++ b/fluent-logger.gemspec
@@ -36,7 +36,7 @@ EOF
   gem.require_paths = ['lib']
 
   gem.add_dependency 'yajl-ruby', '~> 1.0'
-  gem.add_dependency 'msgpack', '0.4.7'
+  gem.add_dependency 'msgpack', '>= 0.4.7'
   gem.add_development_dependency 'rake', '>= 0.9.2'
   gem.add_development_dependency 'rspec', '>= 2.7.0'
   gem.add_development_dependency 'simplecov', '>= 0.5.4'


### PR DESCRIPTION
"rake spec" passes with msgpack 0.5.5 on my environment. (Debian
GNU/Linux amd64 sid) So it seems that fluent-logger can accept 0.5.x
series.
