### PR TITLE
Use at_exit instead of hacky finalizer

### DIFF
--- a/lib/fluent/logger/fluent_logger.rb
+++ b/lib/fluent/logger/fluent_logger.rb
@@ -26,25 +26,6 @@ module Logger
 
 
 class FluentLogger < LoggerBase
-  module Finalizable
-    require 'delegate'
-    def new(*args, &block)
-      obj = allocate
-      obj.instance_eval { initialize(*args, &block) }
-      dc = DelegateClass(obj.class).new(obj)
-      ObjectSpace.define_finalizer(dc, finalizer(obj))
-      dc
-    end
-
-    def finalizer(obj)
-      fin = obj.method(:finalize)
-      proc {|id|
-        fin.call
-      }
-    end
-  end
-  extend Finalizable
-
   BUFFER_LIMIT = 8*1024*1024
   RECONNECT_WAIT = 0.5
   RECONNECT_WAIT_INCR_RATE = 1.5
@@ -103,6 +84,8 @@ class FluentLogger < LoggerBase
       @logger.error "Failed to connect fluentd: #{$!}"
       @logger.error "Connection will be retried."
     end
+
+    at_exit { close }
   end
 
   attr_accessor :limit, :logger, :log_reconnect_error_threshold
@@ -137,10 +120,6 @@ class FluentLogger < LoggerBase
 
   def connect?
     !!@con
-  end
-
-  def finalize
-    close
   end
 
   private

--- a/spec/fluent_logger_spec.rb
+++ b/spec/fluent_logger_spec.rb
@@ -179,7 +179,7 @@ EOF
       it "backward compatible" do
         port = fluentd_port
         fluent_logger = Fluent::Logger::FluentLogger.new('logger-test', 'localhost', port)
-        fluent_logger.method_missing(:instance_eval) { # fluent_logger is delegetor
+        fluent_logger.instance_eval {
           @host.should == 'localhost'
           @port.should == port
         }
@@ -191,7 +191,7 @@ EOF
           :host => 'localhost',
           :port => port
         })
-        fluent_logger.method_missing(:instance_eval) { # fluent_logger is delegetor
+        fluent_logger.instance_eval {
           @host.should == 'localhost'
           @port.should == port
         }

--- a/spec/logger_spec.rb
+++ b/spec/logger_spec.rb
@@ -28,8 +28,7 @@ describe Fluent::Logger do
       Fluent::Logger.open('tag-prefix', {
         :logger => ::Logger.new(fluent_logger_logger_io)
       })
-      # Fluent::Logger::FluentLogger is delegator
-      Fluent::Logger.default.method_missing(:kind_of?, Fluent::Logger::FluentLogger).should be_true
+      Fluent::Logger.default.kind_of?(Fluent::Logger::FluentLogger).should be_true
     }
 
     it('open with BaseLogger class') {


### PR DESCRIPTION
Current code is buggy and blocker of https://github.com/fluent/fluent-logger-ruby/issues/10 .

https://github.com/treasure-data/td-logger-ruby/commit/a72cc1365388b953d7128eae484905b059830491
