### PR TITLE
Fix for issue #10

### DIFF
--- a/lib/fluent/logger/fluent_logger.rb
+++ b/lib/fluent/logger/fluent_logger.rb
@@ -36,7 +36,7 @@ class FluentLogger < LoggerBase
         r / RECONNECT_WAIT_INCR_RATE
       }
 
-  def initialize(tag_prefix, *args)
+  def initialize(tag_prefix = '', *args)
     super()
 
     options = {

--- a/lib/fluent/logger/logger_base.rb
+++ b/lib/fluent/logger/logger_base.rb
@@ -20,7 +20,7 @@ module Logger
 
 class LoggerBase
   def self.open(*args, &block)
-    Fluent::Logger.open(self, *args, &block)
+    Fluent::Logger.open(*args, &block)
   end
 
   def post(tag, map)


### PR DESCRIPTION
@@default_logger is now properly constructed to be of the type passed into Fluent::Logger::FluentLogger.open.
