### PR TITLE
suppress evaluate block in debug log

### DIFF
--- a/lib/fluent/logger/fluent_logger.rb
+++ b/lib/fluent/logger/fluent_logger.rb
@@ -96,7 +96,7 @@ class FluentLogger < LoggerBase
   end
 
   def post_with_time(tag, map, time)
-    @logger.debug { "event: #{tag} #{map.to_json}" rescue nil }
+    @logger.debug { "event: #{tag} #{map.to_json}" rescue nil } if @logger.debug?
     tag = "#{@tag_prefix}.#{tag}" if @tag_prefix
     write [tag, time.to_i, map]
   end


### PR DESCRIPTION
The local variable is evaluated when the block object is created, not at `yield`. 
This patch suppresses the evaluation if debug log is not required. 
