### PR TITLE
Test @con.closed? in FluentLogger#connect?

### DIFF
--- a/lib/fluent/logger/fluent_logger.rb
+++ b/lib/fluent/logger/fluent_logger.rb
@@ -119,7 +119,7 @@ class FluentLogger < LoggerBase
   end
 
   def connect?
-    !!@con
+    @con && !@con.closed?
   end
 
   private


### PR DESCRIPTION
When trying to use fluent-logger in a delayed_job worker, I was getting an error that the connection to fluentd was closed (stack below).  

Looking at the fluentd log in verbose mode, it was clear that connection to fluentd was getting disconnected (probably because of delayed_job's worker fork?)  So, while fluent-logger still had a connection object, it cannot use it since it was closed. 

This PR updates `FluentLogger#connect?` to also check `@conn.closed?`. 

```
delayed_job: process with pid 20383 started.
E, [2014-04-29T21:51:11.773366 #20383] ERROR -- : FluentLogger: Can't send logs to localhost:24224: closed stream
/home/ewebb/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/fluent-logger-0.4.9/lib/fluent/logger/fluent_logger.rb:114:in `close': closed stream (IOError)
    from /home/ewebb/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/fluent-logger-0.4.9/lib/fluent/logger/fluent_logger.rb:114:in `block in close'
    from /home/ewebb/.rbenv/versions/2.0.0-p353/lib/ruby/2.0.0/monitor.rb:211:in `mon_synchronize'
    from /home/ewebb/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/fluent-logger-0.4.9/lib/fluent/logger/fluent_logger.rb:105:in `close'
    from /home/ewebb/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/fluent-logger-0.4.9/lib/fluent/logger/fluent_logger.rb:88:in `block in initialize'
/home/ewebb/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/fluent-logger-0.4.9/lib/fluent/logger/fluent_logger.rb:175:in `close': closed stream (IOError)
    from /home/ewebb/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/fluent-logger-0.4.9/lib/fluent/logger/fluent_logger.rb:175:in `rescue in block in write'
    from /home/ewebb/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/fluent-logger-0.4.9/lib/fluent/logger/fluent_logger.rb:165:in `block in write'
    from /home/ewebb/.rbenv/versions/2.0.0-p353/lib/ruby/2.0.0/monitor.rb:211:in `mon_synchronize'
    from /home/ewebb/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/fluent-logger-0.4.9/lib/fluent/logger/fluent_logger.rb:151:in `write'
    from /home/ewebb/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/fluent-logger-0.4.9/lib/fluent/logger/fluent_logger.rb:101:in `post_with_time'
    from /home/ewebb/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/fluent-logger-0.4.9/lib/fluent/logger/logger_base.rb:28:in `post'
    from /home/ewebb/Source/Projects/keghub-portal/lib/fluentd_logger.rb:97:in `flush'
    from /home/ewebb/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/activesupport-4.0.0/lib/active_support/tagged_logging.rb:72:in `flush'
    from /home/ewebb/Source/Projects/keghub-portal/lib/fluentd_logger.rb:67:in `add_message'
    from /home/ewebb/Source/Projects/keghub-portal/lib/fluentd_logger.rb:59:in `add'
    from /home/ewebb/.rbenv/versions/2.0.0-p353/lib/ruby/2.0.0/logger.rb:463:in `fatal'
    from /home/ewebb/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/delayed_job-4.0.0/lib/delayed/command.rb:106:in `rescue in run'
    from /home/ewebb/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/delayed_job-4.0.0/lib/delayed/command.rb:97:in `run'
    from /home/ewebb/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/delayed_job-4.0.0/lib/delayed/command.rb:92:in `block in run_process'
    from /home/ewebb/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/daemons-1.1.9/lib/daemons/application.rb:255:in `call'
    from /home/ewebb/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/daemons-1.1.9/lib/daemons/application.rb:255:in `block in start_proc'
    from /home/ewebb/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/daemons-1.1.9/lib/daemons/application.rb:264:in `call'
    from /home/ewebb/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/daemons-1.1.9/lib/daemons/application.rb:264:in `start_proc'
    from /home/ewebb/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/daemons-1.1.9/lib/daemons/application.rb:296:in `start'
    from /home/ewebb/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/daemons-1.1.9/lib/daemons/controller.rb:73:in `run'
```
