### PR TITLE
Fix logger base

### DIFF
--- a/fluent-logger.gemspec
+++ b/fluent-logger.gemspec
@@ -38,7 +38,7 @@ EOF
   gem.add_dependency 'yajl-ruby', '~> 1.0'
   gem.add_dependency "msgpack", [">= 0.4.4", "!= 0.5.0", "!= 0.5.1", "!= 0.5.2", "!= 0.5.3", "< 0.6.0"]
   gem.add_development_dependency 'rake', '>= 0.9.2'
-  gem.add_development_dependency 'rspec', '>= 2.7.0'
+  gem.add_development_dependency 'rspec', '~> 2.14'
   gem.add_development_dependency 'simplecov', '>= 0.5.4'
   gem.add_development_dependency 'timecop', '>= 0.3.0'
 end

--- a/lib/fluent/logger/logger_base.rb
+++ b/lib/fluent/logger/logger_base.rb
@@ -20,7 +20,7 @@ module Logger
 
 class LoggerBase
   def self.open(*args, &block)
-    Fluent::Logger.open(*args, &block)
+    Fluent::Logger.open(self, *args, &block)
   end
 
   def post(tag, map)


### PR DESCRIPTION
#10

```ruby
Fluent::Logger::FluentLogger.open(CompoundFluentLogger, :host => 'localhost', :port => 24224)
```
In order to set up @@default_logger, I think that logger_base should not be extended.
Fluent::Logger.open should be used.

```ruby
Fluent::Logger.open(CompoundFluentLogger, :host => 'localhost', :port => 24224)
```

Now, `.open` of all inclusion Logger is an action which sets FluentLogger as @@default_logger and returns it.

