### PR TITLE
Use JSON instead of Yajl.

### DIFF
--- a/fluent-logger.gemspec
+++ b/fluent-logger.gemspec
@@ -30,7 +30,6 @@ EOF
   gem.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   gem.require_paths = ['lib']
 
-  gem.add_dependency 'yajl-ruby', '~> 1.0'
   gem.add_dependency "msgpack", [">= 0.4.4", "!= 0.5.0", "!= 0.5.1", "!= 0.5.2", "!= 0.5.3", "< 0.6.0"]
   gem.add_development_dependency 'rake', '>= 0.9.2'
   gem.add_development_dependency 'rspec', '>= 3.0.0'

--- a/lib/fluent/logger/fluent_logger.rb
+++ b/lib/fluent/logger/fluent_logger.rb
@@ -19,7 +19,7 @@ require 'msgpack'
 require 'socket'
 require 'monitor'
 require 'logger'
-require 'yajl'
+require 'json'
 
 module Fluent
   module Logger
@@ -125,7 +125,7 @@ module Fluent
         begin
           msg.to_msgpack
         rescue NoMethodError
-          Yajl::Parser.parse( Yajl::Encoder.encode(msg) ).to_msgpack
+          JSON.parse(JSON.generate(msg)).to_msgpack
         end
       end
 

--- a/lib/fluent/logger/text_logger.rb
+++ b/lib/fluent/logger/text_logger.rb
@@ -19,15 +19,15 @@ module Fluent
   module Logger
     class TextLogger < LoggerBase
       def initialize
-        require 'yajl'
+        require 'json'
         @time_format = "%b %e %H:%M:%S"
       end
 
       def post_with_time(tag, map, time)
         a = [time.strftime(@time_format), " ", tag, ":"]
-        map.each_pair {|k,v|
+        map.each_pair { |k,v|
           a << " #{k}="
-          a << Yajl::Encoder.encode(v)
+          a << JSON.dump(v)
         }
         post_text a.join
         true


### PR DESCRIPTION
In fluent-logger, there is no merit of yajl's invalid character handling.
If a record has invalid string,
users can sanitize such string with catching an exception.
After removed Yajl, fluent-logger works on JRuby.