### PR TITLE
tag_prefix defaults to nil

### DIFF
--- a/lib/fluent/logger/fluent_logger.rb
+++ b/lib/fluent/logger/fluent_logger.rb
@@ -34,7 +34,7 @@ module Fluent
         r / RECONNECT_WAIT_INCR_RATE
       }
 
-      def initialize(tag_prefix = '', *args)
+      def initialize(tag_prefix = nil, *args)
         super()
 
         options = {


### PR DESCRIPTION
when no tag_prefix specified, logger sends log with tag includes unwanted `.` at
prefix. is this expected behavior?