### PR TITLE
rm "at_exit"

### DIFF
--- a/lib/fluent/logger/fluent_logger.rb
+++ b/lib/fluent/logger/fluent_logger.rb
@@ -82,8 +82,6 @@ module Fluent
           @logger.error "Failed to connect fluentd: #{$!}"
           @logger.error "Connection will be retried."
         end
-
-        at_exit { close }
       end
 
       attr_accessor :limit, :logger, :log_reconnect_error_threshold


### PR DESCRIPTION
at_exit seems to leak memory.

checked with below script
(copied from SamSaffron's
https://github.com/cowboyd/therubyracer/pull/336)

```
require 'objspace'
require 'memory_profiler'
require 'fluent-logger'

def rss
 `ps -eo pid,rss | grep #{Process.pid} | awk '{print $2}'`.to_i
end

MemoryProfiler::Helpers.full_gc
puts "rss: #{rss} live objects #{GC.stat[:heap_live_slots]}"

20.times do
  500.times { |i|
    Fluent::Logger::FluentLogger.new.post("tag", {"a"=>1})
  }

  MemoryProfiler::Helpers.full_gc
  puts "rss: #{rss} live objects #{GC.stat[:heap_live_slots]}"
end
```

before this patch

```
rss: 19528 live objects 38181
rss: 20836 live objects 46999
rss: 21108 live objects 54998
rss: 21948 live objects 62998
rss: 22992 live objects 70998
rss: 24192 live objects 78998
rss: 25248 live objects 86998
rss: 26324 live objects 94998
rss: 27432 live objects 102998
rss: 28556 live objects 110998
...
...

```

after

```
rss: 19840 live objects 38181
rss: 20988 live objects 38998
rss: 21048 live objects 38997
rss: 21056 live objects 38997
rss: 21116 live objects 38997
rss: 21116 live objects 38997
rss: 21116 live objects 38997
rss: 21116 live objects 38997
rss: 21116 live objects 38997
rss: 21116 live objects 38997
rss: 21116 live objects 38997
rss: 21116 live objects 38997
...
...
```