### PR TITLE
Allow logger to respond to conventional rails logging methods

### DIFF
--- a/lib/fluent/logger.rb
+++ b/lib/fluent/logger.rb
@@ -63,5 +63,13 @@ module Fluent
     def self.default=(logger)
       @@default_logger = logger
     end
+
+    def method_missing(m, message)
+      if m.to_s.in?(%w(debug info warn error fatal any))
+        @@default_logger.post(m.to_s, { message: message })
+      else
+        super
+      end
+    end
   end
 end

--- a/lib/fluent/logger.rb
+++ b/lib/fluent/logger.rb
@@ -65,7 +65,7 @@ module Fluent
     end
 
     def method_missing(m, message)
-      if m.to_s.in?(%w(debug info warn error fatal any))
+      if m.to_s.in?(%w(debug info warn error fatal))
         @@default_logger.post(m.to_s, { message: message })
       else
         super


### PR DESCRIPTION
When using gems in a rails application that log under-the-hood, it's helpful to have the fluent-logger be able to respond to those conventional methods. The act-fluent-logger-rails gem responds to these methods, but it doesn't allow differentiation between the logs, so for example, all delayed_job logs will end up in the production.log. If you want to separate them from the production logs, you need to specifically set the delayed job logger to a fluent-logger instance, but delayed_job will call info on whatever you set the logger to be, so to have the logger not break in these instances would be very helpful