### PR TITLE
Allow injection of buffer overflow handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,11 +58,11 @@ Fluent::Logger::NullLogger.open
 
 ## Buffer overflow
 
-You can inject your own custom object to handle buffer overflow in the event of connection failure. This will mitigate the loss of data instead of simply throwing data away.
+You can inject your own custom proc to handle buffer overflow in the event of connection failure. This will mitigate the loss of data instead of simply throwing data away.
 
-Your object must implement a `flush` method which accepts a single argument, which will be the internal buffer of messages from the logger. A typical use-case for this would be writing to disk or possibly writing to Redis.
+Your proc must accept a single argument, which will be the internal buffer of messages from the logger. A typical use-case for this would be writing to disk or possibly writing to Redis.
 
-##### Example 
+##### Example
 ```
 class BufferOverflowHandler
   attr_accessor :buffer
@@ -74,13 +74,12 @@ class BufferOverflowHandler
     end
   end
 end
-```
 
-Then inject this class into the logger like this:
-```
-Fluent::Logger::FluentLogger.new(nil, 
+handler = Proc.new { |messages| BufferOverflowHandler.new.flush(messages) }
+
+Fluent::Logger::FluentLogger.new(nil,
   :host => 'localhost', :port => 24224,
-  :buffer_overflow_handler => BufferOverflowHandler.new)
+  :buffer_overflow_handler => handler)
 ```
 
 |name|description|

--- a/lib/fluent/logger/fluent_logger.rb
+++ b/lib/fluent/logger/fluent_logger.rb
@@ -109,7 +109,7 @@ module Fluent
             rescue => e
               set_last_error(e)
               @logger.error("FluentLogger: Can't send logs to #{@host}:#{@port}: #{$!}")
-              flush_buffer_overflow_handler(@pending)
+              call_buffer_overflow_handler(@pending)
             end
           end
           @con.close if connect?
@@ -171,7 +171,7 @@ module Fluent
             set_last_error(e)
             if @pending.bytesize > @limit
               @logger.error("FluentLogger: Can't send logs to #{@host}:#{@port}: #{$!}")
-              flush_buffer_overflow_handler(@pending)
+              call_buffer_overflow_handler(@pending)
               @pending = nil
             end
             @con.close if connect?
@@ -221,12 +221,12 @@ module Fluent
         raise e
       end
 
-      def flush_buffer_overflow_handler(pending)
+      def call_buffer_overflow_handler(pending)
         if @buffer_overflow_handler
-          @buffer_overflow_handler.flush(pending)
+          @buffer_overflow_handler.call(pending)
         end
       rescue Exception => e
-        @logger.error("FluentLogger: Can't flush buffer overflow handler: #{$!}")
+        @logger.error("FluentLogger: Can't call buffer overflow handler: #{$!}")
       end
 
       def log_reconnect_error

--- a/lib/fluent/logger/fluent_logger.rb
+++ b/lib/fluent/logger/fluent_logger.rb
@@ -62,6 +62,8 @@ module Fluent
         @limit = options[:buffer_limit] || BUFFER_LIMIT
         @log_reconnect_error_threshold = options[:log_reconnect_error_threshold] ||  RECONNECT_WAIT_MAX_COUNT
 
+        @buffer_overflow_handler = options[:buffer_overflow_handler]
+
         if logger = options[:logger]
           @logger = logger
         else
@@ -107,6 +109,7 @@ module Fluent
             rescue => e
               set_last_error(e)
               @logger.error("FluentLogger: Can't send logs to #{@host}:#{@port}: #{$!}")
+              flush_buffer_overflow_handler(@pending)
             end
           end
           @con.close if connect?
@@ -168,6 +171,7 @@ module Fluent
             set_last_error(e)
             if @pending.bytesize > @limit
               @logger.error("FluentLogger: Can't send logs to #{@host}:#{@port}: #{$!}")
+              flush_buffer_overflow_handler(@pending)
               @pending = nil
             end
             @con.close if connect?
@@ -215,6 +219,14 @@ module Fluent
         end
 
         raise e
+      end
+
+      def flush_buffer_overflow_handler(pending)
+        if @buffer_overflow_handler
+          @buffer_overflow_handler.flush(pending)
+        end
+      rescue Exception => e
+        @logger.error("FluentLogger: Can't flush buffer overflow handler: #{$!}")
       end
 
       def log_reconnect_error

--- a/spec/fluent_logger_spec.rb
+++ b/spec/fluent_logger_spec.rb
@@ -248,7 +248,9 @@ EOF
           end
         end
       end
-      let(:buffer_overflow_handler) { BufferOverflowHandler.new }
+
+      let(:handler) { BufferOverflowHandler.new }
+      let(:buffer_overflow_handler) { Proc.new { |messages| handler.flush(messages) } }
 
       it ('post limit over') do
         logger.limit = 100
@@ -265,7 +267,7 @@ EOF
         logger_io.rewind
         logger_io.read.should =~ /Can't send logs to/
 
-        buffer = buffer_overflow_handler.buffer
+        buffer = handler.buffer
 
         buffer[0][0].should == 'logger-test.tag'
         buffer[0][1].should.to_s =~ /\d{10}/

--- a/spec/fluent_logger_spec.rb
+++ b/spec/fluent_logger_spec.rb
@@ -10,7 +10,7 @@ require 'stringio'
 require 'fluent/logger/fluent_logger/cui'
 require 'plugin/out_test'
 
-$log = Fluent::Log.new(StringIO.new) # XXX should remove $log from fluentd 
+$log = Fluent::Log.new(StringIO.new) # XXX should remove $log from fluentd
 
 describe Fluent::Logger::FluentLogger do
   WAIT = ENV['WAIT'] ? ENV['WAIT'].to_f : 0.1
@@ -32,11 +32,14 @@ describe Fluent::Logger::FluentLogger do
     @logger_io = StringIO.new
     logger = ::Logger.new(@logger_io)
     Fluent::Logger::FluentLogger.new('logger-test', {
-      :host   => 'localhost', 
+      :host   => 'localhost',
       :port   => fluentd_port,
       :logger => logger,
+      :buffer_overflow_handler => buffer_overflow_handler
     })
   }
+
+  let(:buffer_overflow_handler) { nil }
 
   let(:logger_io) {
     @logger_io
@@ -104,7 +107,7 @@ EOF
     end
 
     context('post') do
-      it ('success') { 
+      it ('success') {
         expect(logger.post('tag', {'a' => 'b'})).to be true
         wait_transfer
         queue.last.should == ['logger-test.tag', {'a' => 'b'}]
@@ -192,7 +195,7 @@ EOF
       end
     end
   end
-  
+
   context "not running fluentd" do
     context('fluent logger interface') do
       it ('post & close') {
@@ -231,6 +234,46 @@ EOF
         wait_transfer  # even if wait
         logger_io.rewind
         logger_io.read.should =~ /Failed to connect/
+      end
+    end
+
+    context "when a buffer overflow handler is provided" do
+      class BufferOverflowHandler
+        attr_accessor :buffer
+
+        def flush(messages)
+          @buffer ||= []
+          MessagePack::Unpacker.new.feed_each(messages) do |msg|
+            @buffer << msg
+          end
+        end
+      end
+      let(:buffer_overflow_handler) { BufferOverflowHandler.new }
+
+      it ('post limit over') do
+        logger.limit = 100
+        event_1 = {'a' => 'b'}
+        logger.post('tag', event_1)
+        wait_transfer  # even if wait
+        queue.last.should be_nil
+
+        logger_io.rewind
+        logger_io.read.should_not =~ /Can't send logs to/
+
+        event_2 = {'a' => ('c' * 1000)}
+        logger.post('tag', event_2)
+        logger_io.rewind
+        logger_io.read.should =~ /Can't send logs to/
+
+        buffer = buffer_overflow_handler.buffer
+
+        buffer[0][0].should == 'logger-test.tag'
+        buffer[0][1].should.to_s =~ /\d{10}/
+        buffer[0][2].should == event_1
+
+        buffer[1][0].should == 'logger-test.tag'
+        buffer[1][1].should.to_s =~ /\d{10}/
+        buffer[1][2].should == event_2
       end
     end
   end


### PR DESCRIPTION
#### Summary
When the fluent-logger cannot connect to the fluent agent process, the contents of the internal buffer (`@pending`) are discarded when the buffer exceeds the buffer size limit. 

This change allows the optional injection of a handler which is invoked before the buffer is cleared. This allows that data to be handled rather than just thrown away.

#### Intended effect
If no `buffer_overflow_handler ` is provided in the config, there is no change in behaviour.

If a `buffer_overflow_handler` is provided it is invoked before clearing the contents of the internal buffer (`@pending`). The handler must implement a `flush` which accepts a single argument.

#### How I tested
I've added some specs for this, but I am also already running my fork in my production environment and it's working well.

#### Comments
Related issue: https://github.com/fluent/fluent-logger-ruby/issues/32