### PR TITLE
Fix LoggerBase.open method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.bundle
 Gemfile.lock
 pkg/*
 coverage/*

--- a/lib/fluent/logger/logger_base.rb
+++ b/lib/fluent/logger/logger_base.rb
@@ -19,7 +19,7 @@ module Fluent
   module Logger
     class LoggerBase
       def self.open(*args, &block)
-        Fluent::Logger.open(*args, &block)
+        Fluent::Logger.open(self, *args, &block)
       end
 
       def post(tag, map)

--- a/spec/logger_base_spec.rb
+++ b/spec/logger_base_spec.rb
@@ -3,9 +3,21 @@ require 'spec_helper'
 
 describe Fluent::Logger::LoggerBase do
   context "subclass" do
-    subject { Class.new(Fluent::Logger::LoggerBase) }
-    its(:open) {
-      should be_kind_of(Fluent::Logger::LoggerBase)
-    }
+    let(:subclass) { Class.new(Fluent::Logger::LoggerBase) }
+    let(:other_subclass) { Class.new(Fluent::Logger::LoggerBase) }
+
+    describe ".open" do
+      subject(:open) { subclass.open }
+
+      it { should be_kind_of(Fluent::Logger::LoggerBase) }
+
+      it "changes Fluent::Logger.default" do
+        subclass.open
+        expect(Fluent::Logger.default).to be_kind_of(subclass)
+
+        other_subclass.open
+        expect(Fluent::Logger.default).to be_kind_of(other_subclass)
+      end
+    end
   end
 end


### PR DESCRIPTION
It is same #20 . but that is conflicted.

I expects following

```ruby
Fluent::Logger::TestLogger.open
Fluent::Logger.default # => is instance of Fluent::Logger::TestLogger
```

but current behavior is not.