### PR TITLE
Use accessor method in order to ensure default logger existence

### DIFF
--- a/lib/fluent/logger.rb
+++ b/lib/fluent/logger.rb
@@ -49,11 +49,11 @@ module Fluent
     end
 
     def self.post(tag, map)
-      @@default_logger.post(tag, map)
+      default.post(tag, map)
     end
 
     def self.post_with_time(tag, map, time)
-      @@default_logger.post_with_time(tag, map, time)
+      default.post_with_time(tag, map, time)
     end
 
     def self.default


### PR DESCRIPTION
Current behavior:

```ruby
Fluent::Logger.default
Fluent::Logger.post("foo", {bar: 1}) # => OK
```

but, without call `Fluent::Logger.default`

```ruby
Fluent::Logger.post("foo", {bar: 1}) #=> NoMethodError (@@default_logger is nil)
```

I think that the behavior is not expected.