### PR TITLE
If @io is stdout, `ConsoleLogger#close` does not close @io

### DIFF
--- a/lib/fluent/logger/console_logger.rb
+++ b/lib/fluent/logger/console_logger.rb
@@ -46,7 +46,7 @@ module Fluent
       end
 
       def close
-        @io.close
+        @io.close unless @io == STDOUT
         self
       end
     end


### PR DESCRIPTION
Current behavior:

```ruby
Fluent::Logger.default # => Fluent::Logger.default is ConsoleLogger(STDOUT)
Fluent::Logger.open(Fluent::Logger::TestLogger) # => close ConsoleLogger and close inner STDOUT too
```

this behavior crashes many libraries which uses STDOUT.
I have some troubles.