### PR TITLE
Remove yajl-ruby

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,5 @@ gemspec
 gem "simplecov", :require => false
 gem "simplecov-vim"
 
-gem 'yajl-ruby' # FIXME ruby 1.8.7 don't work add_dependency('yajl-ruby')
 gem "fluentd"
 gem 'test-unit'


### PR DESCRIPTION
Remove Gemfile's `yajl-ruby` with a comment `FIXME`. It's no longer needed by https://github.com/fluent/fluent-logger-ruby/pull/25.