### PR TITLE
Fix Deprecation Warnings

### DIFF
--- a/spec/console_logger_spec.rb
+++ b/spec/console_logger_spec.rb
@@ -63,7 +63,7 @@ describe Fluent::Logger::ConsoleLogger do
     it {
       expect {
         Fluent::Logger::ConsoleLogger.new(nil)
-      }.to raise_error
+      }.to raise_error(RuntimeError)
     }
   end
 end

--- a/spec/fluent_logger_spec.rb
+++ b/spec/fluent_logger_spec.rb
@@ -254,25 +254,25 @@ EOF
         event_1 = {'a' => 'b'}
         logger.post('tag', event_1)
         wait_transfer  # even if wait
-        queue.last.should be_nil
+        expect(queue.last).to be(nil)
 
         logger_io.rewind
-        logger_io.read.should_not =~ /Can't send logs to/
+        expect(logger_io.read).not_to match(/Can't send logs to/)
 
         event_2 = {'a' => ('c' * 1000)}
         logger.post('tag', event_2)
         logger_io.rewind
-        logger_io.read.should =~ /Can't send logs to/
+        expect(logger_io.read).to match(/Can't send logs to/)
 
         buffer = handler.buffer
 
-        buffer[0][0].should == 'logger-test.tag'
-        buffer[0][1].should.to_s =~ /\d{10}/
-        buffer[0][2].should == event_1
+        expect(buffer[0][0]).to eq('logger-test.tag')
+        expect(buffer[0][1].to_s).to match(/\d{10}/)
+        expect(buffer[0][2]).to eq(event_1)
 
-        buffer[1][0].should == 'logger-test.tag'
-        buffer[1][1].should.to_s =~ /\d{10}/
-        buffer[1][2].should == event_2
+        expect(buffer[1][0]).to eq('logger-test.tag')
+        expect(buffer[1][1].to_s).to match(/\d{10}/)
+        expect(buffer[1][2]).to eq(event_2)
       end
     end
   end

--- a/spec/logger_spec.rb
+++ b/spec/logger_spec.rb
@@ -12,18 +12,18 @@ describe Fluent::Logger do
     end
 
     it('post') {
-      test_logger.should_receive(:post).with('tag1', {:foo => :bar})
+      expect(test_logger).to receive(:post).with('tag1', {:foo => :bar})
       #allow_any_instance_of(test_logger).to receive(:post).with('tag1', {:foo => :bar})
       Fluent::Logger.post('tag1', {:foo => :bar})
     }
 
     it('close') {
-      test_logger.should_receive(:close)
+      expect(test_logger).to receive(:close)
       Fluent::Logger.close
     }
 
     it('open') {
-      test_logger.should_receive(:close)
+      expect(test_logger).to receive(:close)
       klass = Class.new(Fluent::Logger::LoggerBase)
       fluent_logger_logger_io = StringIO.new
       Fluent::Logger.open('tag-prefix', {
@@ -33,10 +33,10 @@ describe Fluent::Logger do
     }
 
     it('open with BaseLogger class') {
-      test_logger.should_receive(:close)
+      expect(test_logger).to receive(:close)
       klass = Class.new(Fluent::Logger::LoggerBase)
       Fluent::Logger.open(klass)
-      Fluent::Logger.default.class.should == klass
+      expect(Fluent::Logger.default.class).to be klass
     }
   end
 end

--- a/spec/null_logger_spec.rb
+++ b/spec/null_logger_spec.rb
@@ -7,8 +7,8 @@ describe Fluent::Logger::NullLogger do
 
     context "post" do
       it('false') {
-        logger.post('tag1', {:foo => :bar}).should == false
-        logger.post('tag2', {:foo => :baz}).should == false
+        expect(logger.post('tag1', {:foo => :bar})).to be false
+        expect(logger.post('tag2', {:foo => :baz})).to be false
       }
     end
   end

--- a/spec/test_logger_spec.rb
+++ b/spec/test_logger_spec.rb
@@ -18,9 +18,9 @@ describe Fluent::Logger::TestLogger do
       its("last.tag")  { should == "tag2" }
 
       it("tag_queue") {
-        logger.tag_queue('tag1').size.should == 1
-        logger.tag_queue('tag2').size.should == 1
-        logger.tag_queue('tag3').size.should == 0
+        expect(logger.tag_queue('tag1').size).to eq 1
+        expect(logger.tag_queue('tag2').size).to eq 1
+        expect(logger.tag_queue('tag3').size).to eq 0
       }
     end
 


### PR DESCRIPTION
Fixed RSpec deprecation warnings:

## Before
![screenshot](https://cloud.githubusercontent.com/assets/803398/12651642/be8e3208-c62a-11e5-87ca-7b241760c43a.png)

## After

![screenshot](https://cloud.githubusercontent.com/assets/803398/12651657/cf461e9e-c62a-11e5-8c99-98db47a0e19e.png)

I think it looks better :sparkles: 
