### PR TITLE
Implement standard compatible severity formatting to LevelFluentLogger

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ require 'fluent-logger'
 f = Fluent::Logger::LevelFluentLogger.new('fluent')
 
 f.formatter = proc do |severity, datetime, progname, message|
-  map = { level: severity.class == Fixnum ? %w(DEBUG INFO WARN ERROR FATAL ANY)[severity] : severity }
+  map = { level: severity }
   map[:message] = message if message
   map[:progname] = progname if progname
   map[:stage] = ENV['RAILS_ENV']

--- a/lib/fluent/logger/level_fluent_logger.rb
+++ b/lib/fluent/logger/level_fluent_logger.rb
@@ -28,7 +28,7 @@ module Fluent
       def initialize(tag_prefix = nil, *args)
         @level = ::Logger::DEBUG
         @default_formatter = proc do |severity, datetime, progname, message|
-          map = { level: format_severity(severity) }
+          map = { level: severity }
           map[:message] = message if message
           map[:progname] = progname if progname
           map
@@ -50,7 +50,7 @@ module Fluent
             progname = @progname
           end
         end
-        map = format_message(severity, Time.now, progname, message)
+        map = format_message(format_severity(severity), Time.now, progname, message)
         @fluent_logger.post(format_severity(severity).downcase, map)
         true
       end

--- a/spec/level_fluent_logger_spec.rb
+++ b/spec/level_fluent_logger_spec.rb
@@ -145,7 +145,7 @@ describe Fluent::Logger::FluentLogger do
       it ('define formatter') {
         level_logger.level = ::Logger::DEBUG
         level_logger.formatter = proc do |severity, datetime, progname, message|
-          map = { level: severity.class == Fixnum ? %w(DEBUG INFO WARN ERROR FATAL ANY)[severity] : severity }
+          map = { level: severity }
           map[:message] = message if message
           map[:progname] = progname if progname
           map[:stage] = "development"


### PR DESCRIPTION
Hi,

The recently added standard logger compatible `LevelFluentLogger` is great!
I've been tried to use it in my project and noticed that its use of formatter is incompatible with standard one.

That is, `format_severity`, which is a private method of `::Logger`, is used inside the formatter [here](https://github.com/fluent/fluent-logger-ruby/blob/5909d7b2a1f088b98228848ef252cfb6b8cc38d7/lib/fluent/logger/level_fluent_logger.rb#L30-L35). This could be simply because `format_severity` is not applied [here](https://github.com/fluent/fluent-logger-ruby/blob/5909d7b2a1f088b98228848ef252cfb6b8cc38d7/lib/fluent/logger/level_fluent_logger.rb#L53).
In the standard `::Logger` implementation, `format_severity` is applied before passing a severity to formatter [like this](https://github.com/ruby/ruby/blob/990b23bbbc991f7f2c9778fd85ba0a3aa773dbdb/lib/logger.rb#L470).

This PR implements standard log formatter compatible way of severity formatting.
