### PR TITLE
Increase the time for waiting dummy fluentd processes to fix the tests

### DIFF
--- a/spec/fluent_logger_spec.rb
+++ b/spec/fluent_logger_spec.rb
@@ -119,6 +119,8 @@ describe Fluent::Logger::FluentLogger do
         expect {
           logger.post('tag', data)
         }.to raise_error(ArgumentError)
+
+        fluentd.wait_transfer # ensure the fluentd accepted the connection
       }
     end
 
@@ -128,6 +130,7 @@ describe Fluent::Logger::FluentLogger do
         host, port = fluent_logger.instance_eval { [@host, @port] }
         expect(host).to eq 'localhost'
         expect(port).to eq fluentd.port
+        fluentd.wait_transfer # ensure the fluentd accepted the connection
       end
 
       it "hash argument" do
@@ -139,6 +142,7 @@ describe Fluent::Logger::FluentLogger do
         host, port = fluent_logger.instance_eval { [@host, @port] }
         expect(host).to eq 'localhost'
         expect(port).to eq fluentd.port
+        fluentd.wait_transfer # ensure the fluentd accepted the connection
       end
     end
   end

--- a/spec/level_fluent_logger_spec.rb
+++ b/spec/level_fluent_logger_spec.rb
@@ -57,12 +57,14 @@ describe Fluent::Logger::FluentLogger do
         })
         expect(level_fluent_logger.level).to eq 0
         expect(level_fluent_logger.progname).to be_nil
+        fluentd.wait_transfer # ensure the fluentd accepted the connection
       }
 
       it ('close') {
         expect(level_logger).to be_connect
         level_logger.close
         expect(level_logger).not_to be_connect
+        fluentd.wait_transfer # ensure the fluentd accepted the connection
       }
 
       it ('reopen') {
@@ -70,6 +72,7 @@ describe Fluent::Logger::FluentLogger do
         level_logger.reopen
         expect(level_logger).not_to be_connect
         expect(level_logger.info('logger reopen test')).to be true
+        fluentd.wait_transfer # ensure the fluentd accepted the connection
       }
     end
 

--- a/spec/support/dummy_fluentd.rb
+++ b/spec/support/dummy_fluentd.rb
@@ -9,7 +9,7 @@ class DummyFluentd
     output.emits.clear rescue nil
   end
 
-  WAIT = ENV['WAIT'] ? ENV['WAIT'].to_f : 0.1
+  WAIT = ENV['WAIT'] ? ENV['WAIT'].to_f : 0.3
 
   def wait_transfer
     sleep WAIT


### PR DESCRIPTION
Tests are failed due to [recent fluentd updates](https://github.com/fluent/fluentd/pull/1306) (ref: https://github.com/fluent/fluent-logger-ruby/pull/57#issuecomment-260574481).
This could be fixed by increasing the wait time of `DummyFluentd`.
