### PR TITLE
Add UNIX socket support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,19 @@ end
 # output: myapp.access {"agent":"foo"}
 ```
 
+### UNIX socket
+
+```ruby
+require 'fluent-logger'
+
+log = Fluent::Logger::FluentLogger.new(nil, :socket_path  => "/tmp/fluent.sock")
+unless log.post("myapp.access", {"agent"=>"foo"})
+  p log.last_error # You can get last error object via last_error method
+end
+
+# output: myapp.access {"agent":"foo"}
+```
+
 ### Singleton
 ```ruby
 require 'fluent-logger'

--- a/spec/fluent_logger_spec.rb
+++ b/spec/fluent_logger_spec.rb
@@ -226,4 +226,44 @@ describe Fluent::Logger::FluentLogger do
       end
     end
   end
+
+  context "using socket_path" do
+
+    let(:socket_logger) {
+      @logger_io = StringIO.new
+      logger = ::Logger.new(@logger_io)
+      Fluent::Logger::FluentLogger.new('logger-test', {
+        :socket_path   => fluentd.socket_path,
+        :logger => logger,
+        :buffer_overflow_handler => buffer_overflow_handler
+      })
+    }
+
+    context "running fluentd" do
+      before(:all) do
+        @serverengine = DummyServerengine.new
+        @serverengine.startup
+      end
+
+      before(:each) do
+        fluentd.socket_startup
+      end
+
+      after(:each) do
+        fluentd.shutdown
+      end
+
+      after(:all) do
+        @serverengine.shutdown
+      end
+
+      context('post') do
+        it ('success') {
+          expect(socket_logger.post('tag', {'b' => 'a'})).to be true
+          fluentd.wait_transfer
+          expect(fluentd.queue.last).to eq ['logger-test.tag', {'b' => 'a'}]
+        }
+      end
+    end
+  end
 end


### PR DESCRIPTION
Since `fluentd` supports using UNIX domain sockets natively, it seems like a potentially good fit to be able to use the same client semantics to communicate with `fluentd` when client applications will be running on the same machine, eliminating the overhead of using the TCP/IP protocol over the loopback interface. This pull request makes slight alterations to the `FluentLogger` class so that it can optionally use a `UNIXSocket` instead of a `TCPSocket`. Since both classes inherit from `BasicSocket` in Ruby, the interface is the same and the domain socket client can work as a drop in replacement. 