### PR TITLE
Add a timeout option for an IO.select

### DIFF
--- a/lib/fluent/logger.rb
+++ b/lib/fluent/logger.rb
@@ -17,14 +17,15 @@
 #
 module Fluent
   module Logger
-    autoload :ConsoleLogger     , 'fluent/logger/console_logger'
-    autoload :FluentLogger      , 'fluent/logger/fluent_logger'
-    autoload :LevelFluentLogger , 'fluent/logger/level_fluent_logger'
-    autoload :LoggerBase        , 'fluent/logger/logger_base'
-    autoload :TestLogger        , 'fluent/logger/test_logger'
-    autoload :TextLogger        , 'fluent/logger/text_logger'
-    autoload :NullLogger        , 'fluent/logger/null_logger'
-    autoload :VERSION           , 'fluent/logger/version'
+    autoload :ConsoleLogger         , 'fluent/logger/console_logger'
+    autoload :FluentLogger          , 'fluent/logger/fluent_logger'
+    autoload :LevelFluentLogger     , 'fluent/logger/level_fluent_logger'
+    autoload :LoggerBase            , 'fluent/logger/logger_base'
+    autoload :TestLogger            , 'fluent/logger/test_logger'
+    autoload :TextLogger            , 'fluent/logger/text_logger'
+    autoload :NullLogger            , 'fluent/logger/null_logger'
+    autoload :SocketTimeoutException, 'fluent/logger/socket_timeout_exception'
+    autoload :VERSION               , 'fluent/logger/version'
 
     @@default_logger = nil
 

--- a/lib/fluent/logger/socket_timeout_exception.rb
+++ b/lib/fluent/logger/socket_timeout_exception.rb
@@ -1,0 +1,6 @@
+module Fluent
+  module Logger
+    class SocketTimeoutException < StandardError
+    end
+  end
+end

--- a/spec/fluent_logger_spec.rb
+++ b/spec/fluent_logger_spec.rb
@@ -1,4 +1,3 @@
-
 require 'spec_helper'
 require 'support/dummy_serverengine'
 require 'support/dummy_fluentd'
@@ -19,9 +18,15 @@ describe Fluent::Logger::FluentLogger do
       :host   => 'localhost',
       :port   => fluentd.port,
       :logger => logger,
+      :timeout => timeout,
+      :buffer_limit => buffer_limit,
       :buffer_overflow_handler => buffer_overflow_handler
     })
   }
+
+  let(:buffer_limit) { nil }
+
+  let(:timeout) { nil }
 
   let(:buffer_overflow_handler) { nil }
 
@@ -228,6 +233,34 @@ describe Fluent::Logger::FluentLogger do
         expect(buffer[1][1].to_s).to match(/\d{10}/)
         expect(buffer[1][2]).to eq(event_2)
       end
+
+      context "and fluentd is not reading" do
+
+        let(:timeout) { 1 }
+
+        let(:buffer_limit) { 20 }
+
+        before(:each) do
+          fluentd.dead_startup
+        end
+
+        after(:each) do
+          fluentd.dead_shutdown
+        end
+
+        it ('timesout if one is provided') {
+          timed_out = false
+          until handler.buffer || timed_out
+            timed_out = ! Timeout::timeout(3) {
+              logger.post('tag', {'a' => 'b'})
+            }
+          end
+          buffer = handler.buffer
+          expect(buffer).not_to be_nil
+          expect(buffer).not_to be_empty
+        }
+      end
+
     end
   end
 

--- a/spec/support/dummy_fluentd.rb
+++ b/spec/support/dummy_fluentd.rb
@@ -34,6 +34,10 @@ class DummyFluentd
     SOCKET_PATH
   end
 
+  def thread
+    @thread
+  end
+
   def output
     sleep 0.0001 # next tick
     if Fluent::Engine.respond_to?(:match)
@@ -49,6 +53,10 @@ class DummyFluentd
       queue << [tag, record]
     }
     queue
+  end
+
+  def dead_startup
+    @dead_server = TCPServer.open('localhost', port)
   end
 
   def startup
@@ -89,6 +97,10 @@ EOF
       Fluent::Engine.run
     }
     wait_transfer
+  end
+
+  def dead_shutdown
+    @dead_server.close
   end
 
   def shutdown


### PR DESCRIPTION
If for some reason the fluentd instance the logger is connected to is not draining the buffer, the socket receive/send buffers will eventually fill. This causes the next write to block, as the socket will never be ready to write to. Using a `select` with a timeout allows this to be avoided. Simply throwing an exception to use the overflow handler however, will cause the connection to reset. If this happens, a new socket will be opened which means there may be some unbounded number of buffered sockets. When the write has timed out, we can explicitly not close the connection to allow the implementer to choose a reconnection strategy. 