### PR TITLE
fix to_msgpack

### DIFF
--- a/lib/fluent/logger/fluent_logger.rb
+++ b/lib/fluent/logger/fluent_logger.rb
@@ -181,15 +181,15 @@ module Fluent
       private
 
       def to_msgpack(msg)
-        begin
-          @mon.synchronize {
-            res = @packer.pack(msg).to_s
-            @packer.clear
-            res
-          }
-        rescue NoMethodError
-          JSON.parse(JSON.generate(msg)).to_msgpack
-        end
+        @mon.synchronize {
+          res = begin
+                  @packer.pack(msg).to_s
+                rescue NoMethodError
+                  JSON.parse(JSON.generate(msg)).to_msgpack
+                end
+          @packer.clear
+          res
+        }
       end
 
       def suppress_sec

--- a/spec/fluent_logger_spec.rb
+++ b/spec/fluent_logger_spec.rb
@@ -119,6 +119,19 @@ describe Fluent::Logger::FluentLogger do
         expect(logger_data['object']).to be_truthy
       }
 
+      it ('msgpack unsupport data and support data') {
+        logger.post('tag', {'time' => Time.utc(2008, 9, 1, 10, 5, 0)})
+        logger.post('tag', {'time' => '2008-09-01 10:05:00 UTC'})
+
+        fluentd.wait_transfer
+
+        logger_data1 = fluentd.queue.first.last
+        expect(logger_data1['time']).to eq '2008-09-01 10:05:00 UTC'
+
+        logger_data2 = fluentd.queue.last.last
+        expect(logger_data2['time']).to eq '2008-09-01 10:05:00 UTC'
+      }
+
       it ('msgpack and JSON unsupport data') {
         data = {
           'time'   => Time.utc(2008, 9, 1, 10, 5, 0),


### PR DESCRIPTION
When `@packer.pack(msg)` raise NoMethodError, packed data is remained.