### PR TITLE
last_error is defined twice

### DIFF
--- a/lib/fluent/logger/fluent_logger.rb
+++ b/lib/fluent/logger/fluent_logger.rb
@@ -126,7 +126,6 @@ module Fluent
       end
 
       attr_accessor :limit, :logger, :log_reconnect_error_threshold
-      attr_reader :last_error
 
       def last_error
         @last_error[Thread.current.object_id]


### PR DESCRIPTION
Remove duplicated defined method.

https://github.com/fluent/fluent-logger-ruby/blob/7de55ab45dd87bcb781ff6c62a3e68260bbd9560/lib/fluent/logger/fluent_logger.rb#L131

