### PR TITLE
to_json should return String type

### DIFF
--- a/lib/fluent/logger/fluent_logger.rb
+++ b/lib/fluent/logger/fluent_logger.rb
@@ -44,7 +44,7 @@ module Fluent
       end
 
       def to_json(*args)
-        @sec
+        @sec.to_s
       end
     end
 

--- a/spec/fluent_logger_spec.rb
+++ b/spec/fluent_logger_spec.rb
@@ -137,6 +137,16 @@ describe Fluent::Logger::FluentLogger do
         }
       end
 
+      context 'when the message has object which does not have #to_msgpack method' do
+        it 'success with nanosecond' do
+          expect(logger_with_nanosec.pending_bytesize).to eq(0)
+          expect(logger_with_nanosec.post('tag', 'a' => Errno::ETIMEDOUT)).to eq(true)
+          fluentd.wait_transfer
+          expect(fluentd.queue.last).to eq(['logger-test.tag', { 'a' => 'Errno::ETIMEDOUT' }])
+          expect(logger_with_nanosec.pending_bytesize).to eq(0)
+        end
+      end
+
       it ('close after post') {
         expect(logger).to be_connect
         logger.close


### PR DESCRIPTION
Fix https://github.com/fluent/fluent-logger-ruby/issues/77

Copy from fluentd's implement

https://github.com/fluent/fluentd/blob/25b081c49abcc15c72dbd4b69cc347c771e0b89f/lib/fluent/time.rb#L72-L74

