### PR TITLE
Add instruction for installation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,22 @@
 
 A structured event logger
 
+## Installation
+
+Add this line to your application's Gemfile:
+
+```ruby
+gem 'fluent-logger'
+```
+
+And then execute:
+
+    $ bundle install
+
+Or install it yourself as:
+
+    $ gem install fluent-logger
+
 ## Examples
 
 ### Simple


### PR DESCRIPTION
Since I saw the repository name is fluent-logger-ruby, I tried to install this library.

```
gem install fluent-logger-ruby
```

But I can't install it.

Actually, I can install as follows.

```
gem install fluent-logger
```