### PR TITLE
Fix invalid message polluting subsequent message

### DIFF
--- a/lib/fluent/logger/fluent_logger.rb
+++ b/lib/fluent/logger/fluent_logger.rb
@@ -231,8 +231,9 @@ module Fluent
                   @packer.pack(msg).to_s
                 rescue NoMethodError
                   JSON.parse(JSON.generate(msg)).to_msgpack
+                ensure
+                  @packer.clear
                 end
-          @packer.clear
           res
         }
       end

--- a/spec/fluent_logger_spec.rb
+++ b/spec/fluent_logger_spec.rb
@@ -205,6 +205,10 @@ describe Fluent::Logger::FluentLogger do
         expect(fluentd.queue.last).to be_nil
         logger_io.rewind
         logger_io.read =~ /FluentLogger: Can't convert to msgpack:/
+
+        logger.post('tag', { 'a' => 'b' })
+        fluentd.wait_transfer
+        expect(fluentd.queue.last).to eq ['logger-test.tag', { 'a' => 'b' }]
       }
 
       it ('should raise an error when second argument is non hash object') {


### PR DESCRIPTION
A message that cannot be converted to msgpack currently pollutes a subsequent message. For example,

```ruby
logger = Fluent::Logger::FluentLogger.new
logger.post_with_time('tag1', { foo: 1 << 64 }, Time.utc(2023, 12, 05)) # FluentLogger: Can't convert to msgpack: ["tag", 1701734400, {:foo=>18446744073709551616}]: bignum too big to convert into `unsigned long long'
logger.post_with_time('tag2', { bar: 'bar' }, Time.utc(2023, 12, 06))
```

sends the following message

```
2023-12-05T00:00:00+00:00       tag1     {"foo":["tag2",1701820800,{"bar":"bar"}]}
```

instead of the following.

```
2023-12-06T00:00:00+00:00       tag2     {"bar":"bar"}
```