### PR TITLE
gemspec: add logger gem as runtime dependency

### DIFF
--- a/fluent-logger.gemspec
+++ b/fluent-logger.gemspec
@@ -22,6 +22,10 @@ Gem::Specification.new do |gem|
   gem.license       = "Apache-2.0"
 
   gem.add_dependency "msgpack", ">= 1.0.0", "< 2"
+
+  # logger gem that isn't default gems as of Ruby 3.5
+  gem.add_runtime_dependency("logger", ["~> 1.6"])
+
   gem.add_development_dependency 'rake', '>= 0.9.2'
   gem.add_development_dependency 'rspec', '>= 3.0.0'
   gem.add_development_dependency 'rspec-its', '>= 1.1.0'


### PR DESCRIPTION
logger gem will be changed bundled gem since Ruby 3.5.0.
So, when I use fluent-logger-ruby with Ruby 3.4, it show the following warning:

```
/home/watson/.rbenv/versions/3.4.1/lib/ruby/gems/3.4.0/gems/fluent-logger-0.9.1/lib/fluent/logger/fluent_logger.rb:23: warning: logger was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
You can add logger to your Gemfile or gemspec to silence this warning.
```

This patch will fix the warning.
