### PR TITLE
gemspec: refactor definition

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,11 +1,12 @@
-
 source 'https://rubygems.org/'
-
-gem "fluentd", :github => 'fluent/fluentd'
 
 gemspec
 
-gem "simplecov", :require => false
+gem "rake", ">= 0.9.2"
+gem "rspec", ">= 3.0.0"
+gem "rspec-its", ">= 1.1.0"
+gem "timecop", ">= 0.3.0"
+gem "fluentd"
+gem "test-unit"
+gem "simplecov", ">= 0.5.4", require: false
 gem "simplecov-vim"
-
-gem 'test-unit'

--- a/fluent-logger.gemspec
+++ b/fluent-logger.gemspec
@@ -22,14 +22,6 @@ Gem::Specification.new do |gem|
   gem.license       = "Apache-2.0"
 
   gem.add_dependency "msgpack", ">= 1.0.0", "< 2"
-
   # logger gem that isn't default gems as of Ruby 3.5
-  gem.add_runtime_dependency("logger", ["~> 1.6"])
-
-  gem.add_development_dependency 'rake', '>= 0.9.2'
-  gem.add_development_dependency 'rspec', '>= 3.0.0'
-  gem.add_development_dependency 'rspec-its', '>= 1.1.0'
-  gem.add_development_dependency 'simplecov', '>= 0.5.4'
-  gem.add_development_dependency 'timecop', '>= 0.3.0'
-  gem.add_development_dependency 'webrick'
+  gem.add_dependency "logger", "~> 1.6"
 end


### PR DESCRIPTION
* Fix duplicated definition of `simplecov`.
* Move development dependencies to Gemfile.
* Stop forcing the use of the latest version of `fluentd`.
  * Since this prevents testing with old Ruby.
* Remove `webrick`, as it appears not to be used anymore.

Diff of Gemfile.lock

    -GIT
    -  remote: https://github.com/fluent/fluentd.git
    -  revision: bbb87c033e8879d38a546cf099a50c62fa5f37e7
    -  specs:
    -    fluentd (1.19.0)
    -      async-http (~> 0.86)
    -      base64 (~> 0.2)
    -      bundler
    -      cool.io (>= 1.4.5, < 2.0.0)
    -      csv (~> 3.2)
    -      drb (~> 2.2)
    -      http_parser.rb (>= 0.5.1, < 0.9.0)
    -      io-event (< 1.11.0)
    -      io-stream (< 0.8.0)
    -      logger (~> 1.6)
    -      msgpack (>= 1.3.1, < 2.0.0)
    -      serverengine (>= 2.3.2, < 3.0.0)
    -      sigdump (~> 0.2.5)
    -      strptime (>= 0.2.4, < 1.0.0)
    -      tzinfo (>= 1.0, < 3.0)
    -      tzinfo-data (~> 1.0)
    -      uri (~> 1.0)
    -      webrick (~> 1.4)
    -      yajl-ruby (~> 1.0)
    -      zstd-ruby (~> 1.5)
    -
     PATH
       remote: .
       specs:
    @@ -67,6 +41,27 @@
         fiber-local (1.1.0)
           fiber-storage
         fiber-storage (1.0.1)
    +    fluentd (1.19.0)
    +      async-http (~> 0.86)
    +      base64 (~> 0.2)
    +      bundler
    +      cool.io (>= 1.4.5, < 2.0.0)
    +      csv (~> 3.2)
    +      drb (~> 2.2)
    +      http_parser.rb (>= 0.5.1, < 0.9.0)
    +      io-event (< 1.11.0)
    +      io-stream (< 0.8.0)
    +      logger (~> 1.6)
    +      msgpack (>= 1.3.1, < 2.0.0)
    +      serverengine (>= 2.3.2, < 3.0.0)
    +      sigdump (~> 0.2.5)
    +      strptime (>= 0.2.4, < 1.0.0)
    +      tzinfo (>= 1.0, < 3.0)
    +      tzinfo-data (~> 1.0)
    +      uri (~> 1.0)
    +      webrick (~> 1.4)
    +      yajl-ruby (~> 1.0)
    +      zstd-ruby (~> 1.5)
         http_parser.rb (0.8.0)
         io-endpoint (0.15.2)
         io-event (1.10.2)
    @@ -132,15 +127,14 @@

     DEPENDENCIES
       fluent-logger!
    -  fluentd!
    +  fluentd rake (>= 0.9.2) rspec (>= 3.0.0) rspec-its (>= 1.1.0)
    -  simplecov
    +  simplecov (>= 0.5.4) simplecov-vim test-unit timecop (>= 0.3.0)
    -  webrick

     BUNDLED WITH
        2.6.8