### PR TITLE
level_fluent_logger: call super to improve compatibility with logger

### DIFF
--- a/lib/fluent/logger/level_fluent_logger.rb
+++ b/lib/fluent/logger/level_fluent_logger.rb
@@ -26,7 +26,8 @@ module Fluent
     class LevelFluentLogger < ::Logger
 
       def initialize(tag_prefix = nil, *args)
-        @level = ::Logger::DEBUG
+        super(nil)
+
         @default_formatter = proc do |severity, datetime, progname, message|
           map = { level: severity }
           map[:message] = message if message


### PR DESCRIPTION
Fix https://github.com/fluent/fluent-logger-ruby/issues/100

```ruby
require "bundler/inline"
gemfile do
  source "https://rubygems.org"
  gem "fluent-logger" #, path: "/home/watson/src/fluent-logger-ruby"
  gem "logger", "= 1.6.0"
end

f = Fluent::Logger::LevelFluentLogger.new('fluent')
f.info("some application running.")
p f.level
```

The compatibility has lost since logger gem v1.6.0.
So, the above code causes following `NoMethodError` error.

```
$ ruby logger.rb
E, [2025-09-05T18:03:49.313233 #102418] ERROR -- : Failed to connect fluentd: Connection refused - connect(2) for "localhost" port 24224
E, [2025-09-05T18:03:49.313616 #102418] ERROR -- : Connection will be retried.
E, [2025-09-05T18:03:49.314104 #102418] ERROR -- : FluentLogger: Can't send logs to localhost:24224: Connection refused - connect(2) for "localhost" port 24224
/home/watson/.rbenv/versions/3.4.5/lib/ruby/gems/3.4.0/gems/logger-1.6.0/lib/logger.rb:384:in 'Logger#level': undefined method '[]' for nil (NoMethodError)

    @level_override[Fiber.current] || @level
                   ^^^^^^^^^^^^^^^
        from logger.rb:10:in '<main>'
```

We should call `super` in inherited class.

FYI:
This problem will be fixed with logger 1.7.0 with https://github.com/ruby/logger/commit/1efdf6b0145d875b94623bd43a8666378cd007b9 